### PR TITLE
Componentizando trecho de alerta para post não revisado

### DIFF
--- a/src/components/AppShell/index.tsx
+++ b/src/components/AppShell/index.tsx
@@ -81,7 +81,7 @@ export default function AppShell({ children }: PropsWithChildren) {
 				<VerticalNavigation onNavigation={close} />
 			</MantineAppShell.Navbar>
 
-			<MantineAppShell.Main>
+			<MantineAppShell.Main mb="md">
 				{children}
 				<BackToTopButton />
 			</MantineAppShell.Main>

--- a/src/components/BookPostView/index.tsx
+++ b/src/components/BookPostView/index.tsx
@@ -1,9 +1,9 @@
-import { Alert, Anchor, Box, Container, Divider, Title } from "@mantine/core";
+import { Box, Container, Divider, Title } from "@mantine/core";
 import markdownToHtml from "~/lib/markdownToHtml";
 import type { Post as PostType } from "~/types/post";
 
-import { IconInfoCircle } from "@tabler/icons-react";
 import { Article } from "../Article";
+import { ReviewAlert } from "../ReviewAlert";
 
 type BookPostView = {
 	post: PostType;
@@ -14,20 +14,7 @@ export async function BookPostView({ post }: BookPostView) {
 
 	return (
 		<Container pt="md">
-			<Alert
-				mb={20}
-				variant="light"
-				color="gray"
-				title="Tradução"
-				icon={<IconInfoCircle />}
-			>
-				Este texto foi traduzido com ferramentas de IA, e ainda não foi revisado
-				por um humano. Pode conter erros graves. Confira sempre o link do texto
-				original:{" "}
-				<Anchor size="sm" href={post.translatedFrom} target="_blank">
-					{post.translatedFrom}
-				</Anchor>
-			</Alert>
+			<ReviewAlert link={post.translatedFrom} />
 
 			<Box id="book-post-view-header" component="header">
 				<Title order={1}>{post.title}</Title>

--- a/src/components/PostView/index.tsx
+++ b/src/components/PostView/index.tsx
@@ -11,6 +11,7 @@ import markdownToHtml from "~/lib/markdownToHtml";
 import type { Post as PostType } from "~/types/post";
 
 import { Article } from "../Article";
+import { ReviewAlert } from "../ReviewAlert";
 import classes from "./styles.module.css";
 
 type PostProps = {
@@ -22,6 +23,8 @@ export async function PostView({ post }: PostProps) {
 
 	return (
 		<Container pt="md">
+			<ReviewAlert link={post.translatedFrom} />
+
 			<Breadcrumbs component="nav" className={classes.breadcrumb} mb="md">
 				<Anchor href="/">Início</Anchor>
 
@@ -45,6 +48,7 @@ export async function PostView({ post }: PostProps) {
 							href={post.translatedFrom}
 							target="_blank"
 							rel="noopener noreferrer"
+							c="blue"
 						>
 							{post.translatedFrom}
 						</Anchor>

--- a/src/components/ReviewAlert/index.tsx
+++ b/src/components/ReviewAlert/index.tsx
@@ -1,0 +1,25 @@
+import { Alert, Anchor } from "@mantine/core";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+export function ReviewAlert({ link }: { link: string | undefined }) {
+	return (
+		<Alert
+			mb={20}
+			variant="light"
+			color="gray"
+			title="Tradução"
+			icon={<IconInfoCircle />}
+		>
+			Este texto foi traduzido com ferramentas de IA, e ainda não foi revisado
+			por um humano. Pode conter erros graves.{" "}
+			{link && (
+				<>
+					Confira sempre o link do texto original:{" "}
+					<Anchor size="sm" href={link} target="_blank" c="blue">
+						{link}
+					</Anchor>
+				</>
+			)}
+		</Alert>
+	);
+}


### PR DESCRIPTION
Componentizei o trecho de alerta para post não revisado e inclui para aparecer nos artigos também. Também inclui uma cor nos links para destacar que são clicáveis.

![image](https://github.com/user-attachments/assets/af2959cc-dfcc-4a1b-b033-4b4681013b7d)
> Agora o alerta para post não revisado também aparece nos artigos

## Outras mudanças
https://github.com/coisasdoalto/coisasdoalto.org/pull/33/commits/a24ca455b6f7c782bc16479e19f7fdecbe3f9afb Inclui um padding no final da página.
Acho que fica melhor pois o botão de voltar ao topo não fica em cima do conteúdo

![image](https://github.com/user-attachments/assets/bb798caf-b8b1-4abf-9df8-940740714e23)
